### PR TITLE
feat: Build MVP CLI, write directly to stdout, enforce Colorizer cont…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 testdata/
 go.sum
+cb

--- a/catbow/rainbow.go
+++ b/catbow/rainbow.go
@@ -44,7 +44,7 @@ func (rb *RainbowStrategy) Cleanup() string {
 	return ansi.Reset
 }
 
-func NewRainbow(opts RainbowOptions) *RainbowStrategy {
+func NewRainbowStrategy(opts RainbowOptions) *RainbowStrategy {
 	return &RainbowStrategy{
 		opts:       opts,
 		cursor:     0,
@@ -52,6 +52,10 @@ func NewRainbow(opts RainbowOptions) *RainbowStrategy {
 		greenShift: 2 * math.Pi / 3,
 		blueShift:  4 * math.Pi / 3,
 	}
+}
+
+func NewRainbowStrategyDefaultOpts() *RainbowStrategy {
+	return NewRainbowStrategy(*NewDefaultRainbowOptions())
 }
 
 /*
@@ -62,7 +66,7 @@ func NewRainbow(opts RainbowOptions) *RainbowStrategy {
 			"#%02X%02X%02X" % [ red, green, blue ]
 	    end
 */
-func (rb *RainbowStrategy) ColorizeRune(r rune) string {
+func (rb *RainbowStrategy) colorizeRune(r rune) string {
 	if rb.opts.NoColor {
 		return string(r)
 	}
@@ -80,7 +84,7 @@ func (rb *RainbowStrategy) ColorizeRune(r rune) string {
 	rb.cursor += 1
 
 	return fmt.Sprintf(
-		"\033[38;2;%X;%X;%X%cm",
+		ansi.Esc+"[38;2;%d;%d;%dm%c",
 		int(math.Floor(red)),
 		int(math.Floor(green)),
 		int(math.Floor(blue)),

--- a/catbow/rainbow_test.go
+++ b/catbow/rainbow_test.go
@@ -9,14 +9,14 @@ import (
 func setupRainbow() *RainbowStrategy {
 	opts := *NewDefaultRainbowOptions()
 	opts.Seed = 1
-	return NewRainbow(opts)
+	return NewRainbowStrategy(opts)
 }
 
 func TestColorGeneration(t *testing.T) {
 
 	rb := setupRainbow()
-	outR := rb.ColorizeRune('r')
-	outB := rb.ColorizeRune('b')
+	outR := rb.colorizeRune('r')
+	outB := rb.colorizeRune('b')
 
 	assert.Contains(t, outR, ansi.Esc+"[38;2")
 	assert.Contains(t, outR, "rm")
@@ -24,20 +24,20 @@ func TestColorGeneration(t *testing.T) {
 	assert.Contains(t, outB, ansi.Esc+"[38;2")
 	assert.Contains(t, outB, "bm")
 
-	assert.NotEqual(t, outR, rb.ColorizeRune('r'))
+	assert.NotEqual(t, outR, rb.colorizeRune('r'))
 }
 
 func TestNoColorGeneration(t *testing.T) {
 	rb := setupRainbow()
 	rb.opts.NoColor = true
 
-	assert.Equal(t, string('r'), rb.ColorizeRune('r'))
+	assert.Equal(t, string('r'), rb.colorizeRune('r'))
 
 }
 
 func TestColorReset(t *testing.T) {
 	rb := setupRainbow()
-	out := rb.ColorizeRune('a')
+	out := rb.colorizeRune('a')
 	assert.NotContains(t, out, ansi.Reset)
 	out = rb.Cleanup()
 	assert.Contains(t, out, ansi.Reset)

--- a/cmd/catbow/main.go
+++ b/cmd/catbow/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("catbow entry point")
-}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/lordxarus/catbow/catbow"
+)
+
+func newMockReader() *bufio.Reader {
+	cmd := exec.Command("./generate_text.py")
+	text, err := cmd.Output()
+	println(len(text))
+	if err != nil {
+		fmt.Println(err)
+	}
+	r := bufio.NewReader(strings.NewReader(string(text)))
+	return r
+}
+
+// simplest runner to test Cleanup()
+func main() {
+
+	var r *bufio.Reader
+
+	if slices.Contains(os.Args, "-gen") {
+		r = newMockReader()
+	} else {
+		r = bufio.NewReader(os.Stdin)
+	}
+	w := io.Writer(os.Stdout)
+	colorizer := catbow.NewColorizer(catbow.NewRainbowStrategyDefaultOpts())
+	err := colorizer.Colorize(r, w)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	/* this will be replaced by
+	AnsiFormatter satisfies Formatter  interface
+	colFmt := AnsiFormatter()
+	if colFmt.(catbow.Cleanupper) {
+		w.colFmt.Cleanup()
+	}
+	*/
+	if cleaner, ok := colorizer.Strategy.(catbow.Cleanupper); ok {
+		_, err := w.Write([]byte(cleaner.Cleanup()))
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+	}
+}


### PR DESCRIPTION
### Overview

This PR builds the initial CLI application. The CLI is responsible for consuming
the catbow package, wiring up the components, and managing the application
lifecycle.

This PR also tightens the contract between the user and catbow by unexporting
colorizeRune which is an internal method. This ensures the user gets the
benefits of the IO management provided by Colorizer.

Buffered Readers and Writers have been replaced by unbuffered version from "io",
this was done to achieve streaming functionality. When using buffered IO catbow
would not output anything on small inputs and have a delay (while buffer filled)
on any output. The buffered Reader in colorize was switched out in favor for a
bufio.Scanner which provides a more idiomatic way to scan through runes.

**This PR resolves two output related bugs**

No Reset on EOF: Whenever a terminal application terminates it is polite to set the 
SGR attributes back to default. To do so this PR creates a new interface called Cleanupper 
to  formalize the Cleanup() behavior. After the input stream hits EOF, Colorizer will exit.
Upon exit the CLI will call cleaner.Cleanup() which returns the ANSI reset sequence.
This will be used later by a ColorEncoder which will decouple the ColorStrategy and the details
of the output destination. 

Missing Output Bug: Colorizer now uses an unbuffered Writer which ensures
data written to stdout appears immediately without having to wait for a buffer
to be exhausted. This fixes the bug where catbow would not output anything
on small inputs. Incidentally this also saves the overhead of calling Flush()
after every write as was necessary before. 

### How to Test
- Compile the new binary: `go build . -o cb`
- Create and pipe test text into the binary: `./generate.py --num-lines 2 | tee | cb`
- Verify Reset: The output lines should be colored, and your shell prompt
after the command finishes must be your default terminal color (proving the
reset worked).
- Verify Output: You should have two sets of two identical lines, proving the flush
	worked

### Known Issues
This PR does not address the bug where the RainbowStrategy logic itself is
flawed.