### PR TITLE
perf(gen-text): re-architecture to use generators for sentences 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 testdata/
 go.sum
+private/
 cb

--- a/catbow/encoder/ansi/escape_sequences.go
+++ b/catbow/encoder/ansi/escape_sequences.go
@@ -1,4 +1,4 @@
 package ansi
 
 const Esc = "\x1B"
-const Reset = Esc + "0m"
+const Reset = Esc + "[0m"

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 	w := io.Writer(os.Stdout)
 	colorizer := catbow.NewColorizer(catbow.NewRainbowStrategyDefaultOpts())
 	err := colorizer.Colorize(r, w)
+
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
This pull request aims to reduce the memory usage of the generator when creating many lines and/or very long lines. This is achieved through the use of a generator instead of an array that stores the generated lines. 

Changes also include: 

- Improved code quality by removing magic numbers
- Improved user experience by outputting progress when given the --file option