### PR TITLE
fix: Rainbow logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,6 @@ test:
 
 clean:
 	go clean
-	rm ${BINARY_NAME}
+	# does go clean -testcache do go clean? 
+	go clean -testcache
+	rm -f ${BINARY_NAME}

--- a/catbow/catbow.go
+++ b/catbow/catbow.go
@@ -8,6 +8,16 @@ import (
 	"unicode/utf8"
 )
 
+type rgbColor struct {
+	R uint8
+	G uint8
+	B uint8
+}
+
+func (rgb rgbColor) String() string {
+	return fmt.Sprintf("rgb(%d, %d, %d)", rgb.R, rgb.G, rgb.B)
+}
+
 type Cleanupper interface {
 	Cleanup() string
 }
@@ -42,16 +52,16 @@ func (c *Colorizer) Colorize(r io.Reader, w io.Writer) error {
 		if r == utf8.RuneError {
 			switch size {
 			case 0:
-				return errors.New("RuneError: DecodeRune got passed an empty buffer")
+				return errors.New("error: DecodeRune got passed an empty buffer")
 			case 1:
-				return errors.New("colorize: invalid encoding for bytes % +q")
+				return errors.New("error: invalid encoding for bytes % +q")
 			}
 		}
 
 		coloredString := c.Strategy.colorizeRune(r)
 		_, err := w.Write([]byte(coloredString))
 		if err != nil {
-			return fmt.Errorf("colorize: error while writing to stdout: %w", err)
+			return fmt.Errorf("error: exception while writing to stdout: %w", err)
 		}
 	}
 

--- a/catbow/rainbow_test.go
+++ b/catbow/rainbow_test.go
@@ -1,44 +1,99 @@
 package catbow
 
 import (
-	"github.com/lordxarus/catbow/catbow/encoder/ansi"
-	"github.com/stretchr/testify/assert"
+	"fmt"
 	"testing"
+
+	"github.com/jeremysball/catbow/catbow/encoder/ansi"
+	"github.com/stretchr/testify/assert"
 )
 
-func setupRainbow() *RainbowStrategy {
-	opts := *NewDefaultRainbowOptions()
+func setupTestRainbow() *rainbowStrategy {
+	opts := NewRainbowOptions()
 	opts.Seed = 1
+	opts.Spread = 3
+	opts.Frequency = .1
 	return NewRainbowStrategy(opts)
 }
 
-func TestColorGeneration(t *testing.T) {
+func TestColorControlCodes(t *testing.T) {
 
-	rb := setupRainbow()
+	rb := setupTestRainbow()
 	outR := rb.colorizeRune('r')
 	outB := rb.colorizeRune('b')
 
 	assert.Contains(t, outR, ansi.Esc+"[38;2")
-	assert.Contains(t, outR, "rm")
+	assert.Contains(t, outR, "mr")
 
 	assert.Contains(t, outB, ansi.Esc+"[38;2")
-	assert.Contains(t, outB, "bm")
+	assert.Contains(t, outB, "mb")
 
+	// increase the offset to avoid collisions
+	for range 20 {
+		rb.colorizeRune('r')
+	}
 	assert.NotEqual(t, outR, rb.colorizeRune('r'))
 }
 
 func TestNoColorGeneration(t *testing.T) {
-	rb := setupRainbow()
-	rb.opts.NoColor = true
+	rb := setupTestRainbow()
+	rb.Opts.NoColor = true
 
 	assert.Equal(t, string('r'), rb.colorizeRune('r'))
 
 }
 
 func TestColorReset(t *testing.T) {
-	rb := setupRainbow()
+	rb := setupTestRainbow()
 	out := rb.colorizeRune('a')
-	assert.NotContains(t, out, ansi.Reset)
-	out = rb.Cleanup()
-	assert.Contains(t, out, ansi.Reset)
+	assert.NotContains(t, out, ansi.Esc+"[0m")
+	out = rb.CleanupStr()
+	assert.Equal(t, out, ansi.Esc+"[0m")
+}
+
+func TestRainbowAlgorithm(t *testing.T) {
+	rb := setupTestRainbow()
+
+	defer fmt.Println(rb.CleanupStr())
+
+	assert.Equal(t, 2.0, rb.offset)
+	rgb := rb.calculateRainbow(rb.offset)
+	assert.Equal(t, rgbColor{136, 234, 14}, rgb)
+
+	rb.offset += 10
+	rgb = rb.calculateRainbow(rb.offset)
+	assert.Equal(t, rgbColor{177, 205, 2}, rgb)
+}
+
+func TestOffsetProgression(t *testing.T) {
+	/*
+		Explanation of the lolcat offset:
+	*/
+	rb := setupTestRainbow()
+	defer fmt.Println(rb.CleanupStr())
+
+	// offset gets initialized to seed (1 if using setupRainbow() test setup)
+	// in lolcat the input is loaded into memory and split on lines. before the first
+	// iteration the offset is incremented so we start with seed + 1
+
+	assert.Equal(t, 2.0, rb.offset)
+	rb.colorizeRune('a')
+	assert.InDelta(t, 7.0/3.0, rb.offset, .001)
+	assert.Equal(t, 2.3333333333333335, rb.offset)
+	rb.colorizeRune('s')
+	assert.InDelta(t, 8.0/3.0, rb.offset, .001)
+	rb.colorizeRune('d')
+	assert.InDelta(t, 9.0/3.0, rb.offset, .001)
+	rb.colorizeRune('f')
+	assert.InDelta(t, 10.0/3.0, rb.offset, .001)
+	rb.colorizeRune('\n')
+
+	// rb.offset is reset to what it was when entering the
+	// line loop in this case it gets set back to 2.0
+
+	// then incremented again before the next iteration of the line loop
+	assert.Equal(t, 3.0, rb.offset)
+
+	// EOF
+
 }

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -43,3 +43,33 @@ Colorizer:
 - `func NewColorizer(Options) *Colorizer`
 - `func Colorize(w io.Writer, r io.Reader) error`
 
+Rainbow Algorithm:
+
+```python
+import math
+
+freq = .1
+spread = 3
+seed = 1
+offset = seed + 1
+scled_offset = lambda: offset / spread
+red_shift = 0
+green_shift = (2*mathi) / 3
+blue_shift = (4*mathi) / 3
+def col(shift):
+    return round(((math.sin(freq*scled_offset() + shift) * 127) + 128) % 255)
+```
+Color math:
+
+freq: .05
+spread: 1.05
+seed: 1
+
+// first character, offset starts at seed + 1
+offset: 2
+scled_offset = 2 / 1.05 = 1.9047619047619047
+
+red = sin(.05 * scled_offset) + 0 * 127 + 128
+red = 128.09509418758475
+green = 139.08327219152056
+blue = 150.07145019545635

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,4 +1,5 @@
 ## TODO
+<<<<<<< HEAD
 - Fix rainbow logic
 ## NICE TO TODO
 - animated text 
@@ -37,6 +38,39 @@ CLI:
       --no-color
       -a, --animate
       -D, --duration (how long each segment animates for)
+=======
+- Create pull request for test/fix-gen-perf branch
+- Approve + rebase pull request
+
+- Create pull request for fix/rainbow-logic
+- Rebase pull request
+
+- change defaults to -freq .1 -spread 3
+- add short option variants
+## NICE TO TODO
+- animated text 
+
+- maybe an ability to have "profiles" of settings?
+for example if you know that you'll only be seeing pretty short
+messages you can use different settings to when you want to colorize
+    - or just simple -short and -long flags
+a wall of text
+COLORS:
+
+support for [various types](https://gist.github.com/kurahaupo/6ce0eaefe5e730841f03cb82b061daa2) of escape codes will be detected (TODO: how?) (--color-mode <truecolor | 256col | 16col> to override):
+- 256 color palette ONLY
+- 16 color palette ONLY 
+  references:
+  - [ANSI escape list](https://gist.github.com/JBlond/2fea43a3049b38287e5e9cefc87b2124)
+  - [ANSI visualization](https://github.com/fidian/ansi)
+CLI:
+  - Cobra for argument parsing
+  - automatically generate shell completions via build system 
+  - package shell completions*
+  - flags:
+      -a, --animate
+      -D, --duration (how long each segment animates for)
+
 ### lolcat Feature Parity Todo
 - ability to interleave files and stdin: `catbow file0 - file1`* 
 - when we are in a tty (our stdin is attached to a terminal) AND no files AND

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lordxarus/catbow
+module github.com/jeremysball/catbow
 
 go 1.25.1
 

--- a/main.go
+++ b/main.go
@@ -2,20 +2,23 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"os"
 	"os/exec"
-	"slices"
 	"strings"
 
-	"github.com/lordxarus/catbow/catbow"
+	"github.com/jeremysball/catbow/catbow"
 )
 
-func newMockReader() *bufio.Reader {
-	cmd := exec.Command("./generate_text.py")
+func newMockReader(genLineLen, genNumLines int) *bufio.Reader {
+	cmd := exec.Command(
+		"./generate_text.py",
+		fmt.Sprintf("--line-width=%d", genLineLen),
+		fmt.Sprintf("--num-lines=%d", genNumLines))
 	text, err := cmd.Output()
-	println(len(text))
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -28,13 +31,56 @@ func main() {
 
 	var r *bufio.Reader
 
-	if slices.Contains(os.Args, "-gen") {
-		r = newMockReader()
+	var shouldGenerate bool
+	var freq float64
+	var spread float64
+	var seed int
+	var genLineLen int
+	var genNumLines int
+
+	// these defaults SHOULD come from the Strategy itself
+	flag.BoolVar(
+		&shouldGenerate,
+		"gen",
+		false,
+		"Enable generating random text to colorize")
+	flag.IntVar(&seed,
+		"seed",
+		0,
+		"Changes what color the rainbow starts on. 0 == random")
+	flag.Float64Var(&spread,
+		"spread",
+		1.05,
+		"Rotates the rainbow")
+	flag.Float64Var(&freq,
+		"freq",
+		0.05,
+		"Controls the horizontal width of each color band")
+	flag.IntVar(&genLineLen, "gen-line-width", 80, "")
+	flag.IntVar(&genNumLines, "gen-num-lines", 256, "")
+
+	flag.Parse()
+
+	w := io.Writer(os.Stdout)
+	if shouldGenerate {
+		r = newMockReader(genLineLen, genNumLines)
 	} else {
 		r = bufio.NewReader(os.Stdin)
 	}
-	w := io.Writer(os.Stdout)
-	colorizer := catbow.NewColorizer(catbow.NewRainbowStrategyDefaultOpts())
+
+	opts := catbow.NewRainbowOptions()
+	if seed == 0 {
+		// just picked a number here - the only thing that
+		// matters it that it doesn't become MASSIVE and overflow
+		// the color calculation
+		opts.Seed = rand.IntN(65535)
+	} else {
+		opts.Seed = seed
+	}
+	opts.Spread = spread
+	opts.Frequency = freq
+
+	colorizer := catbow.NewColorizer(catbow.NewRainbowStrategy(opts))
 	err := colorizer.Colorize(r, w)
 
 	if err != nil {
@@ -48,6 +94,7 @@ func main() {
 		w.colFmt.Cleanup()
 	}
 	*/
+
 	if cleaner, ok := colorizer.Strategy.(catbow.Cleanupper); ok {
 		_, err := w.Write([]byte(cleaner.Cleanup()))
 		if err != nil {

--- a/parity.fish
+++ b/parity.fish
@@ -1,0 +1,13 @@
+#!/usr/bin/env fish
+set cwd "$(pwd)"
+pushd /tmp
+if not test -d cb-e2e
+    mkdir cb-e2e
+end
+pushd cb-e2e
+command $cwd/generate_text.py --line-width 4 --num-lines 1 1>data.txt
+cat data.txt | catbow -freq .31 -spread 3 -seed 420 1>cb.txt
+cat data.txt | lolcat -S 420 --force 1>lc.txt
+diff cb.txt lc.txt
+popd
+popd


### PR DESCRIPTION
### Description
This PR aligns our rainbow algorithm behavior to the specification (lolcat's algorithm). Previously the algorithms wildly diverged with the same input and parameters. Alongside the correct behavior, there are now tests written to ensure the algorithm's correctness. Architectural changes were also made: RgbColor is introduced as a facility to pass around a color, and rainbowOptions and rainbowStrategy were also unexported to further enforce the boundary between our code and the user. This PR also adds flags support for the CLI to configure parameters of the algorithm. The Makefile was also edited to include go clean -testcache (what a trap!). 

### Why
These changes were made to further progress towards satisfying our main requirement for the project; create a drop-in lolcat replacement. 

### How to Test
```bash
make clean
go test ./catbow
```