### PR TITLE
docs: bring DESIGN.md up to date, prune and add four items to TODO.md, provide a better help text for flags

### DIFF
--- a/catbow/rainbow.go
+++ b/catbow/rainbow.go
@@ -36,8 +36,7 @@ func NewRainbowOptions() *rainbowOptions {
 }
 
 /*
-	rainbowStrategy is stateful and therefore not re-usable. To colorize a new
-
+rainbowStrategy is stateful and therefore not re-usable. To colorize a new
 stream, create another strategy.
 */
 type rainbowStrategy struct {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -30,20 +30,23 @@ number of lines). I want rainbow text but fast.
 - calls `Colorizer`
 - uses standard Go interfaces `Reader` and `Writer` to decouple library from main
 #### catbow package:
-##### `ColorMath`:
-- Responsible for the actual math and production of colored strings
-- Pure functions
-- `func rainbow(freq, i float64) (r, g, b uint)`
+### ColorStrategy
+  `type ColorStrategy interface {
+  	colorizeRune(r rune) string
+  }`
+##### RainbowStrategy:
+RainbowStrategy is stateful and therefore not re-usable. To colorize a new
+stream, create another strategy. Implements ColorStrategy
+- Pure functions:
+- func (rb *rainbowStrategy) calculateRainbow(offset float64) rgbColor 
 
-Colorizer:
-- Stateful 
-- Uses ColorMath to produce escaped strings
-- Reads and writes to injected `Reader` and `Writer`
-- `Options` struct (contains options required for the operation of the Colorizer)
-- `func NewColorizer(Options) *Colorizer`
-- `func Colorize(w io.Writer, r io.Reader) error`
+#### Colorizer:
+Embeds a ColorStrategy and uses its colorizeRune method to colorize runes
+scanned from the Reader and writes them to the supplied Writer 
+- `func NewColorizer(ColorStrategy) *Colorizer`
+- `func (*Colorizer) Colorize(io.Writer, io.Reader) error`
 
-Rainbow Algorithm:
+### Rainbow Algorithm:
 
 ```python
 import math

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,75 +1,25 @@
-## TODO
-<<<<<<< HEAD
-- Fix rainbow logic
-## NICE TO TODO
+### TODO
+- fix install instructions in README.md
+- bash / interactive bug (see issue #5)
+- rewrite generate_text in go 
+- extract encoding out of the ColorStrategy(color strategy simply deals in
+RgbColor structs) and into an Encoder interface (the encoder is injected into
+the Colorizer)
+
+### NICE TO TODO
 - animated text 
-  - lolcat suffers when there are a lack of newlines or very long lines and loses the
-    pattern
-    lolcat creates a vertical rainbow pattern by incrementing an offset each time it encounters
-    a newline. 
-  - there are two schools of thought:
-    - always increment offset
-      - we don't get the rainbow pattern vertically.
-      - we do get an unbroken pattern on a single line.
-      - I think we would also find that in this scheme newlines
-        would be jarring 
-    - only increment on newlines
-      - issue stated aboved
-      - we do get a nice rainbow pattern in what I imagine is the majority of
-      usecases (and my usecase)
 
-      I think we can likely get the best of both worlds by doing 2 until we see
-      that our line is bigger than a maximum and then we can switch strategies and
-      redraw the entire line 
-
-COLORS:
-
+### Colors:
 support for [various types](https://gist.github.com/kurahaupo/6ce0eaefe5e730841f03cb82b061daa2) of escape codes will be detected (TODO: how?) (--color-mode <truecolor | 256col | 16col> to override):
 - 256 color palette ONLY
 - 16 color palette ONLY 
   references:
   - [ANSI escape list](https://gist.github.com/JBlond/2fea43a3049b38287e5e9cefc87b2124)
   - [ANSI visualization](https://github.com/fidian/ansi)
-CLI:
+### CLI:
   - Cobra for argument parsing
   - automatically generate shell completions via build system 
   - package shell completions*
-  - flags:
-      --no-color
-      -a, --animate
-      -D, --duration (how long each segment animates for)
-=======
-- Create pull request for test/fix-gen-perf branch
-- Approve + rebase pull request
-
-- Create pull request for fix/rainbow-logic
-- Rebase pull request
-
-- change defaults to -freq .1 -spread 3
-- add short option variants
-## NICE TO TODO
-- animated text 
-
-- maybe an ability to have "profiles" of settings?
-for example if you know that you'll only be seeing pretty short
-messages you can use different settings to when you want to colorize
-    - or just simple -short and -long flags
-a wall of text
-COLORS:
-
-support for [various types](https://gist.github.com/kurahaupo/6ce0eaefe5e730841f03cb82b061daa2) of escape codes will be detected (TODO: how?) (--color-mode <truecolor | 256col | 16col> to override):
-- 256 color palette ONLY
-- 16 color palette ONLY 
-  references:
-  - [ANSI escape list](https://gist.github.com/JBlond/2fea43a3049b38287e5e9cefc87b2124)
-  - [ANSI visualization](https://github.com/fidian/ansi)
-CLI:
-  - Cobra for argument parsing
-  - automatically generate shell completions via build system 
-  - package shell completions*
-  - flags:
-      -a, --animate
-      -D, --duration (how long each segment animates for)
 
 ### lolcat Feature Parity Todo
 - ability to interleave files and stdin: `catbow file0 - file1`* 

--- a/main.go
+++ b/main.go
@@ -51,11 +51,11 @@ func main() {
 	flag.Float64Var(&spread,
 		"spread",
 		1.05,
-		"Rotates the rainbow")
+		"Will stretch the rainbow vertically")
 	flag.Float64Var(&freq,
 		"freq",
 		0.05,
-		"Controls the horizontal width of each color band")
+		"Controls how quickly colors transition")
 	flag.IntVar(&genLineLen, "gen-line-width", 80, "")
 	flag.IntVar(&genNumLines, "gen-num-lines", 256, "")
 


### PR DESCRIPTION
This PR brings DESIGN.md into reality with the implementation and makes sure it is a true reflection of the code. The TODO.md has been pruned of old / superfluous information and four items were added to the TODO list. The help text for the CLI flags has been replaced with text from DESIGN.md which I found more accurate and intuitive. 